### PR TITLE
Correct no import errors from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ extern crate memreader;
 use memreader::{MemReader, ProvidesSlices};
 
 use std::env::args;
+use std::io::Read;
 
 fn main() {
   let args: Vec<String> = args().skip(1).collect();


### PR DESCRIPTION
README example contains an error:

> no method named `read_exact` found for type `memreader::slice::MemorySlice<'_>` in the current scope

I just added `std::io::Read` import in tis example